### PR TITLE
Add option to exclude repos

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+*   @confluentinc/builds-automations-and-repositories

--- a/README.rst
+++ b/README.rst
@@ -39,6 +39,7 @@ CLI Usage is as follows::
                   [--prefer-ssh] [-v]
                   [--keychain-name OSX_KEYCHAIN_ITEM_NAME]
                   [--keychain-account OSX_KEYCHAIN_ITEM_ACCOUNT]
+                  [--exclude [REPOSITORY [REPOSITORY ...]]]
                   USER
 
     Backup a github account
@@ -102,6 +103,8 @@ CLI Usage is as follows::
       --keychain-account OSX_KEYCHAIN_ITEM_ACCOUNT
                             OSX ONLY: account field of password item in OSX
                             keychain that holds the personal access or OAuth token
+      --exclude [REPOSITORY [REPOSITORY ...]]
+                            names of repositories to exclude from backup.
 
 
 The package can be used to backup an *entire* organization or repository, including issues and wikis in the most appropriate format (clones for wikis, json files for issues).

--- a/bin/github-backup
+++ b/bin/github-backup
@@ -290,6 +290,10 @@ def parse_args():
     parser.add_argument('--keychain-account',
                         dest='osx_keychain_item_account',
                         help='OSX ONLY: account field of password item in OSX keychain that holds the personal access or OAuth token')
+    parser.add_argument('--exclude',
+                        dest='exclude',
+                        help='names of repositories to exclude',
+                        nargs="*")
     return parser.parse_args()
 
 
@@ -595,6 +599,8 @@ def filter_repositories(args, unfiltered_repositories):
         repositories = [r for r in repositories if r.get('language') and r.get('language').lower() in languages]  # noqa
     if name_regex:
         repositories = [r for r in repositories if name_regex.match(r['name'])]
+    if args.exclude:
+        repositories = [r for r in repositories if r['name'] not in args.exclude]
 
     return repositories
 


### PR DESCRIPTION
This tool backs up our repos. It is out of date with upstream. I'm cherry-picking these changes just so we can skip backing up some very large archived repos.