### PR TITLE
Add support for using the vault token generated for the github app.

### DIFF
--- a/bin/github-backup
+++ b/bin/github-backup
@@ -403,12 +403,10 @@ def _update_githubapp_token(current_token):
             _token_cache['token'] = new_token
             _token_cache['last_modified'] = last_modified
 
-        if current_token != _token_cache['token']:
-            return _token_cache['token']
+            if current_token != new_token:
+                return new_token
     else:
         log_error('No token found in ~/.gh-token')
-
-    return current_token
 
 
 def retrieve_data(args, template, query_args=None, single_request=False):

--- a/bin/github-backup
+++ b/bin/github-backup
@@ -393,7 +393,7 @@ def get_github_repo_url(args, repository):
 def _update_githubapp_token(current_token):
     global _token_cache
     token_path = os.path.expanduser('~/.gh-token')
-
+    # Default to the current token
     new_token = current_token
     if os.path.exists(token_path):
         last_modified = os.path.getmtime(token_path)

--- a/bin/github-backup
+++ b/bin/github-backup
@@ -431,7 +431,6 @@ def retrieve_data(args, template, query_args=None, single_request=False):
             log_info("Auth is initialized")
             log_info("Adding to header")
             request.add_header('Authorization', 'Basic '.encode('ascii') + auth)
-        elif args.username and auth is None:
         r, errors = _get_response(request, auth, template)
 
         status_code = int(r.getcode())

--- a/bin/github-backup
+++ b/bin/github-backup
@@ -38,6 +38,11 @@ from github_backup import __version__
 
 FNULL = open(os.devnull, 'w')
 
+_token_cache = {
+    'token': None,
+    'last_modified': 0
+}
+
 
 def log_error(message):
     if type(message) == str:
@@ -323,7 +328,8 @@ def get_auth(args, encode=True):
         if args.token.startswith(_path_specifier):
             args.token = open(args.token[len(_path_specifier):],
                               'rt').readline().strip()
-        auth = args.token + ':' + 'x-oauth-basic'
+        return args.token
+
     elif args.username:
         if not args.password:
             args.password = getpass.getpass()
@@ -382,6 +388,27 @@ def get_github_repo_url(args, repository):
     return repo_url
 
 
+def _update_githubapp_token(current_token):
+    global _token_cache
+    token_path = os.path.expanduser('~/.gh-token')
+
+    if os.path.exists(token_path):
+        last_modified = os.path.getmtime(token_path)
+
+        if last_modified > _token_cache['last_modified']:
+            with open(token_path, "r") as f:
+                new_token = f.read().strip()
+            _token_cache['token'] = new_token
+            _token_cache['last_modified'] = last_modified
+
+        if current_token != _token_cache['token']:
+            return _token_cache['token']
+    else:
+        log_error('No token found in ~/.gh-token')
+
+    return current_token
+
+
 def retrieve_data(args, template, query_args=None, single_request=False):
     auth = get_auth(args)
     query_args = get_query_args(query_args)
@@ -389,6 +416,8 @@ def retrieve_data(args, template, query_args=None, single_request=False):
     page = 0
     data = []
 
+    auth = _update_githubapp_token(auth)
+ 
     while True:
         page = page + 1
         request = _construct_request(per_page, page, query_args, template, auth)  # noqa
@@ -397,9 +426,18 @@ def retrieve_data(args, template, query_args=None, single_request=False):
         status_code = int(r.getcode())
 
         if status_code != 200:
-            template = 'API request returned HTTP {0}: {1}'
-            errors.append(template.format(status_code, r.reason))
-            log_error(errors)
+            err_template = 'API request returned HTTP {0}: {1}'
+            errors.append(err_template.format(status_code, r.reason))
+            if status_code == 401:
+                auth = _update_githubapp_token(auth)
+                request = _construct_request(per_page, page, query_args, template, auth)  # noqa
+                r, errors = _get_response(request, auth, template)
+
+                status_code = int(r.getcode())
+                if status_code != 200:
+                    err_template = 'API request returned HTTP {0}: {1}'
+                    errors.append(err_template.format(status_code, r.reason))
+                    log_error(errors)
 
         response = json.loads(r.read().decode('utf-8'))
         if len(errors) == 0:
@@ -457,7 +495,7 @@ def _construct_request(per_page, page, query_args, template, auth):
 
     request = Request(template + '?' + querystring)
     if auth is not None:
-        request.add_header('Authorization', 'Basic '.encode('ascii') + auth)
+        request.add_header('Authorization', 'Bearer ' + auth)
     log_info('Requesting {}?{}'.format(template, querystring))
     return request
 

--- a/bin/github-backup
+++ b/bin/github-backup
@@ -426,6 +426,7 @@ def retrieve_data(args, template, query_args=None, single_request=False):
         if args.token and auth is not None:
             request.add_header('Authorization', 'Bearer ' + auth)  # noqa
         elif args.username and auth is not None:
+            print("Have auth initialized")
             request.add_header('Authorization', 'Basic '.encode('ascii') + auth)
         r, errors = _get_response(request, auth, template)
 

--- a/bin/github-backup
+++ b/bin/github-backup
@@ -303,7 +303,7 @@ def parse_args():
 
 
 def get_auth(args, encode=True):
-    auth = None
+    auth = {}
 
     if args.osx_keychain_item_name:
         if not args.osx_keychain_item_account:
@@ -318,7 +318,10 @@ def get_auth(args, encode=True):
                         '-s', args.osx_keychain_item_name,
                         '-a', args.osx_keychain_item_account,
                         '-w'], stderr=devnull).strip())
-                auth = token + ':' + 'x-oauth-basic'
+                auth["basic_auth"] = token + ':' + 'x-oauth-basic'
+                if encode:
+                    auth["basic_auth"] = base64.b64encode(auth["basic_auth"].encode('ascii'))
+                
             except:
                 log_error('No password item matching the provided name and account could be found in the osx keychain.')
     elif args.osx_keychain_item_account:
@@ -328,8 +331,10 @@ def get_auth(args, encode=True):
         if args.token.startswith(_path_specifier):
             args.token = open(args.token[len(_path_specifier):],
                               'rt').readline().strip()
+        auth["token"] = args.token                    
+    
         # Return the token as is                      
-        return args.token
+        return auth
 
     elif args.username:
         if not args.password:
@@ -338,17 +343,16 @@ def get_auth(args, encode=True):
             password = args.password
         else:
             password = urlquote(args.password)
-        auth = args.username + ':' + password
-    elif args.password:
+        auth["basic_auth"] = args.username + ':' + password
+        if encode:
+            auth["basic_auth"] = base64.b64encode(auth["basic_auth"].encode('ascii'))
+
         log_error('You must specify a username for basic auth')
 
     if not auth:
         return None
 
-    if not encode:
-        return auth
-
-    return base64.b64encode(auth.encode('ascii'))
+    return auth
 
 
 def get_github_api_host(args):
@@ -423,37 +427,15 @@ def retrieve_data(args, template, query_args=None, single_request=False):
  
     while True:
         page = page + 1
-        request = _construct_request(per_page, page, query_args, template)
-        if args.token and auth is not None:
-            request.add_header('Authorization', 'Bearer ' + auth)  # noqa
-        elif args.username and auth is not None:
-            print("Have auth initialized")
-            log_info("Auth is initialized")
-            log_info("Adding to header")
-            request.add_header('Authorization', 'Basic '.encode('ascii') + auth)
+        request = _construct_request(per_page, page, query_args, template, auth)
+       
         r, errors = _get_response(request, auth, template)
 
         status_code = int(r.getcode())
 
         if status_code != 200:
             err_template = 'API request returned HTTP {0}: {1}'
-            errors.append(err_template.format(status_code, r.reason))
-            if status_code == 401:
-                if args.token:
-                    auth = _update_githubapp_token(auth)
-                    request = _construct_request(per_page, page, query_args, template)  # noqa
-                    if auth is not None:
-                        request.add_header('Authorization', 'Bearer ' + auth)
-                    r, errors = _get_response(request, auth, template)
-
-                    status_code = int(r.getcode())
-                    if status_code != 200:
-                        err_template = 'API request returned HTTP {0}: {1}'
-                        errors.append(err_template.format(status_code, r.reason))
-                        log_error(errors)
-                else:
-                    log_error(errors)
-                
+            errors.append(err_template.format(status_code, r.reason))                
 
         response = json.loads(r.read().decode('utf-8'))
         if len(errors) == 0:
@@ -503,14 +485,20 @@ def _get_response(request, auth, template):
     return r, errors
 
 
-def _construct_request(per_page, page, query_args, template):
+def _construct_request(per_page, page, query_args, template, auth):
     querystring = urlencode(dict(list({
         'per_page': per_page,
         'page': page
     }.items()) + list(query_args.items())))
 
     request = Request(template + '?' + querystring)
-    
+    auth = _update_githubapp_token(auth)
+    if auth:
+        if 'token' in auth:
+            request.add_header('Authorization', 'Bearer ' + auth)  # noqa
+        elif 'basic_auth' in auth:
+            request.add_header('Authorization', 'Basic '.encode('ascii') + auth)
+
     log_info('Requesting {}?{}'.format(template, querystring))
     return request
 

--- a/bin/github-backup
+++ b/bin/github-backup
@@ -417,7 +417,8 @@ def retrieve_data(args, template, query_args=None, single_request=False):
     page = 0
     data = []
 
-    auth = _update_githubapp_token(auth)
+    if args.token:
+        auth = _update_githubapp_token(auth)
  
     while True:
         page = page + 1
@@ -430,15 +431,19 @@ def retrieve_data(args, template, query_args=None, single_request=False):
             err_template = 'API request returned HTTP {0}: {1}'
             errors.append(err_template.format(status_code, r.reason))
             if status_code == 401:
-                auth = _update_githubapp_token(auth)
-                request = _construct_request(per_page, page, query_args, template, auth)  # noqa
-                r, errors = _get_response(request, auth, template)
+                if args.token:
+                    auth = _update_githubapp_token(auth)
+                    request = _construct_request(per_page, page, query_args, template, auth)  # noqa
+                    r, errors = _get_response(request, auth, template)
 
-                status_code = int(r.getcode())
-                if status_code != 200:
-                    err_template = 'API request returned HTTP {0}: {1}'
-                    errors.append(err_template.format(status_code, r.reason))
+                    status_code = int(r.getcode())
+                    if status_code != 200:
+                        err_template = 'API request returned HTTP {0}: {1}'
+                        errors.append(err_template.format(status_code, r.reason))
+                        log_error(errors)
+                else:
                     log_error(errors)
+                
 
         response = json.loads(r.read().decode('utf-8'))
         if len(errors) == 0:

--- a/bin/github-backup
+++ b/bin/github-backup
@@ -501,7 +501,7 @@ def _construct_request(per_page, page, query_args, template, auth):
     if auth:
         if 'token' in auth:
             auth['token']= _update_githubapp_token(auth['token'])
-            request.add_header('Authorization', 'Bearer ' + auth['token')  # noqa
+            request.add_header('Authorization', 'Bearer ' + auth['token'])  # noqa
         elif 'basic_auth' in auth:
             request.add_header('Authorization', 'Basic '.encode('ascii') + auth['basic_auth'])  # noqa
 

--- a/bin/github-backup
+++ b/bin/github-backup
@@ -333,9 +333,6 @@ def get_auth(args, encode=True):
                               'rt').readline().strip()
         auth["token"] = args.token                    
     
-        # Return the token as is                      
-        return auth
-
     elif args.username:
         if not args.password:
             args.password = getpass.getpass()
@@ -422,9 +419,6 @@ def retrieve_data(args, template, query_args=None, single_request=False):
     page = 0
     data = []
 
-    if args.token:
-        auth = _update_githubapp_token(auth)
- 
     while True:
         page = page + 1
         request = _construct_request(per_page, page, query_args, template, auth)
@@ -492,12 +486,12 @@ def _construct_request(per_page, page, query_args, template, auth):
     }.items()) + list(query_args.items())))
 
     request = Request(template + '?' + querystring)
-    auth = _update_githubapp_token(auth)
     if auth:
         if 'token' in auth:
-            request.add_header('Authorization', 'Bearer ' + auth)  # noqa
+            new_token = _update_githubapp_token(auth['token'])
+            request.add_header('Authorization', 'Bearer ' + new_token)  # noqa
         elif 'basic_auth' in auth:
-            request.add_header('Authorization', 'Basic '.encode('ascii') + auth)
+            request.add_header('Authorization', 'Basic '.encode('ascii') + auth['basic_auth'])  # noqa
 
     log_info('Requesting {}?{}'.format(template, querystring))
     return request

--- a/bin/github-backup
+++ b/bin/github-backup
@@ -394,7 +394,6 @@ def _update_githubapp_token(current_token):
     global _token_cache
     token_path = os.path.expanduser('~/.gh-token')
     # Default to the current token
-    new_token = current_token
     if os.path.exists(token_path):
         last_modified = os.path.getmtime(token_path)
 
@@ -404,8 +403,11 @@ def _update_githubapp_token(current_token):
             log_info('Token updated from ~/.gh-token')
             _token_cache['token'] = new_token
             _token_cache['last_modified'] = last_modified
+
+        if current_token != _token_cache['token']:
+            return _token_cache['token']
         
-        return new_token
+        return current_token
     else:
         log_error('No token found in ~/.gh-token')
 

--- a/bin/github-backup
+++ b/bin/github-backup
@@ -425,26 +425,13 @@ def retrieve_data(args, template, query_args=None, single_request=False):
         request = _construct_request(per_page, page, query_args, template, auth)
        
         r, errors = _get_response(request, auth, template)
-
         status_code = int(r.getcode())
 
         if status_code != 200:
             err_template = 'API request returned HTTP {0}: {1}'
-            if status_code == 401:
-                if args.token:
-                    auth['token'] = _update_githubapp_token(auth['token'])
-                    request = _construct_request(per_page, page, query_args, template, auth)  # noqa
-                    r, errors = _get_response(request, auth, template)
-
-                    status_code = int(r.getcode())
-                    if status_code != 200:
-                        err_template = 'API request returned HTTP again {0}: {1}'
-                        errors.append(err_template.format(status_code, r.reason))
-                        log_error(errors)
-                else:
-                    log_error(errors)
-            errors.append(err_template.format(status_code, r.reason))                
-
+            errors.append(err_template.format(status_code, r.reason))
+            log_error(errors)
+            
         response = json.loads(r.read().decode('utf-8'))
         if len(errors) == 0:
             if type(response) == list:

--- a/bin/github-backup
+++ b/bin/github-backup
@@ -412,6 +412,7 @@ def _update_githubapp_token(current_token):
 
 def retrieve_data(args, template, query_args=None, single_request=False):
     auth = get_auth(args)
+    
     query_args = get_query_args(query_args)
     per_page = 100
     page = 0
@@ -427,7 +428,10 @@ def retrieve_data(args, template, query_args=None, single_request=False):
             request.add_header('Authorization', 'Bearer ' + auth)  # noqa
         elif args.username and auth is not None:
             print("Have auth initialized")
+            log_info("Auth is initialized")
+            log_info("Adding to header")
             request.add_header('Authorization', 'Basic '.encode('ascii') + auth)
+        elif args.username and auth is None:
         r, errors = _get_response(request, auth, template)
 
         status_code = int(r.getcode())

--- a/bin/github-backup
+++ b/bin/github-backup
@@ -394,6 +394,7 @@ def _update_githubapp_token(current_token):
     global _token_cache
     token_path = os.path.expanduser('~/.gh-token')
 
+    new_token = current_token
     if os.path.exists(token_path):
         last_modified = os.path.getmtime(token_path)
 
@@ -402,11 +403,8 @@ def _update_githubapp_token(current_token):
                 new_token = f.read().strip()
             _token_cache['token'] = new_token
             _token_cache['last_modified'] = last_modified
-
-        if current_token != new_token:
-            return new_token
         
-        return current_token
+        return new_token
     else:
         log_error('No token found in ~/.gh-token')
 

--- a/bin/github-backup
+++ b/bin/github-backup
@@ -401,6 +401,7 @@ def _update_githubapp_token(current_token):
         if last_modified > _token_cache['last_modified']:
             with open(token_path, "r") as f:
                 new_token = f.read().strip()
+            log_info('Token updated from ~/.gh-token')
             _token_cache['token'] = new_token
             _token_cache['last_modified'] = last_modified
         
@@ -427,6 +428,19 @@ def retrieve_data(args, template, query_args=None, single_request=False):
 
         if status_code != 200:
             err_template = 'API request returned HTTP {0}: {1}'
+            if status_code == 401:
+                if args.token:
+                    auth['token'] = _update_githubapp_token(auth['token'])
+                    request = _construct_request(per_page, page, query_args, template, auth)  # noqa
+                    r, errors = _get_response(request, auth, template)
+
+                    status_code = int(r.getcode())
+                    if status_code != 200:
+                        err_template = 'API request returned HTTP again {0}: {1}'
+                        errors.append(err_template.format(status_code, r.reason))
+                        log_error(errors)
+                else:
+                    log_error(errors)
             errors.append(err_template.format(status_code, r.reason))                
 
         response = json.loads(r.read().decode('utf-8'))
@@ -486,9 +500,8 @@ def _construct_request(per_page, page, query_args, template, auth):
     request = Request(template + '?' + querystring)
     if auth:
         if 'token' in auth:
-            new_token = _update_githubapp_token(auth['token'])
-            auth['token'] = new_token
-            request.add_header('Authorization', 'Bearer ' + new_token)  # noqa
+            auth['token']= _update_githubapp_token(auth['token'])
+            request.add_header('Authorization', 'Bearer ' + auth['token')  # noqa
         elif 'basic_auth' in auth:
             request.add_header('Authorization', 'Basic '.encode('ascii') + auth['basic_auth'])  # noqa
 

--- a/bin/github-backup
+++ b/bin/github-backup
@@ -328,6 +328,7 @@ def get_auth(args, encode=True):
         if args.token.startswith(_path_specifier):
             args.token = open(args.token[len(_path_specifier):],
                               'rt').readline().strip()
+        # Return the token as is                      
         return args.token
 
     elif args.username:
@@ -561,14 +562,15 @@ def check_git_lfs_install():
 def retrieve_repositories(args, authenticated_user):
     log_info('Retrieving repositories')
     single_request = False
-    if args.user == authenticated_user['login']:
-        # we must use the /user/repos API to be able to access private repos
-        template = 'https://{0}/user/repos'.format(
-            get_github_api_host(args))
-    else:
-        template = 'https://{0}/users/{1}/repos'.format(
-            get_github_api_host(args),
-            args.user)
+    if authenticated_user:
+        if args.user == authenticated_user['login']:
+            # we must use the /user/repos API to be able to access private repos
+            template = 'https://{0}/user/repos'.format(
+                get_github_api_host(args))
+        else:
+            template = 'https://{0}/users/{1}/repos'.format(
+                get_github_api_host(args),
+                args.user)
 
     if args.organization:
         template = 'https://{0}/orgs/{1}/repos'.format(
@@ -1038,8 +1040,13 @@ def main():
 
     log_info('Backing up user {0} to {1}'.format(args.user, output_directory))
 
-    authenticated_user = get_authenticated_user(args)
-    repositories = retrieve_repositories(args, authenticated_user)
+    if args.token:
+        log_info('Using token authentication')
+        repositories = retrieve_repositories(args, None)
+    elif args.username:
+        log_info('Using basic authentication with username {0}'.format(args.username))
+        authenticated_user = get_authenticated_user(args)
+        repositories = retrieve_repositories(args, authenticated_user)
     repositories = filter_repositories(args, repositories)
     backup_repositories(args, output_directory, repositories)
     backup_account(args, output_directory)

--- a/bin/github-backup
+++ b/bin/github-backup
@@ -422,7 +422,11 @@ def retrieve_data(args, template, query_args=None, single_request=False):
  
     while True:
         page = page + 1
-        request = _construct_request(per_page, page, query_args, template, auth)  # noqa
+        request = _construct_request(per_page, page, query_args, template)
+        if args.token and auth is not None:
+            request.add_header('Authorization', 'Bearer ' + auth)  # noqa
+        elif args.username and auth is not None:
+            request.add_header('Authorization', 'Basic '.encode('ascii') + auth)
         r, errors = _get_response(request, auth, template)
 
         status_code = int(r.getcode())
@@ -433,7 +437,9 @@ def retrieve_data(args, template, query_args=None, single_request=False):
             if status_code == 401:
                 if args.token:
                     auth = _update_githubapp_token(auth)
-                    request = _construct_request(per_page, page, query_args, template, auth)  # noqa
+                    request = _construct_request(per_page, page, query_args, template)  # noqa
+                    if auth is not None:
+                        request.add_header('Authorization', 'Bearer ' + auth)
                     r, errors = _get_response(request, auth, template)
 
                     status_code = int(r.getcode())
@@ -493,15 +499,14 @@ def _get_response(request, auth, template):
     return r, errors
 
 
-def _construct_request(per_page, page, query_args, template, auth):
+def _construct_request(per_page, page, query_args, template):
     querystring = urlencode(dict(list({
         'per_page': per_page,
         'page': page
     }.items()) + list(query_args.items())))
 
     request = Request(template + '?' + querystring)
-    if auth is not None:
-        request.add_header('Authorization', 'Bearer ' + auth)
+    
     log_info('Requesting {}?{}'.format(template, querystring))
     return request
 

--- a/bin/github-backup
+++ b/bin/github-backup
@@ -403,10 +403,10 @@ def _update_githubapp_token(current_token):
             _token_cache['token'] = new_token
             _token_cache['last_modified'] = last_modified
 
-            if current_token != new_token:
-                return new_token
-            
-            return current_token
+        if current_token != new_token:
+            return new_token
+        
+        return current_token
     else:
         log_error('No token found in ~/.gh-token')
 

--- a/bin/github-backup
+++ b/bin/github-backup
@@ -405,6 +405,8 @@ def _update_githubapp_token(current_token):
 
             if current_token != new_token:
                 return new_token
+            
+            return current_token
     else:
         log_error('No token found in ~/.gh-token')
 

--- a/bin/github-backup
+++ b/bin/github-backup
@@ -487,6 +487,7 @@ def _construct_request(per_page, page, query_args, template, auth):
     if auth:
         if 'token' in auth:
             new_token = _update_githubapp_token(auth['token'])
+            auth['token'] = new_token
             request.add_header('Authorization', 'Bearer ' + new_token)  # noqa
         elif 'basic_auth' in auth:
             request.add_header('Authorization', 'Basic '.encode('ascii') + auth['basic_auth'])  # noqa


### PR DESCRIPTION
Right now `ConfluentSemaphore` user is being used for backup and we need to move away from using this as the authentication as a part of capsician efforts.

A new backup app was created and installed for both confluentinc and confluent-partners account

It can be viewed from the admin account - https://github.com/settings/apps/apply-github-backup

We are switching to using token with `-t` instead of using username and password.    We need to add the Bearer to using the token as is.   

Furthermore,  as token refreshes,  we are updating the auth as and when needed.  

Link to passing job using this branch with pip install. -  https://semaphore.ci.confluent.io/jobs/921ae045-70bb-4a9d-8755-85570c0e2ec9

