### PR TITLE
added a retry option for 422 errors

### DIFF
--- a/bin/github-backup
+++ b/bin/github-backup
@@ -527,6 +527,12 @@ def _request_http_error(exc, auth, errors):
 
         time.sleep(delta)
         should_continue = True
+    
+    elif exc.code == 422:
+        print("Potentially endpoint spammed detected, sleeping for 60 seconds and retrying")
+        time.sleep(60)
+        should_continue = True
+
     return errors, should_continue
 
 


### PR DESCRIPTION
A 422 error occurs when there are a lot of issues (10000+) in a repo. So I am assuming this could be because it thinks the endpoint is spammed, so adding a wait time after the request fails with 422. 