### PR TITLE
Use graphql to fetch issues and pulls

### DIFF
--- a/bin/github-backup
+++ b/bin/github-backup
@@ -478,7 +478,7 @@ def retrieve_data_graphql(args, graphql_url, query, req_type, query_vars=None, s
                     break
             elif type(response) == dict and single_request:
                 data.append(response)
-        page_info = response["data"]["repository"][req_type]["pageInfo"]
+        page_info = decoded_json["data"]["repository"][req_type]["pageInfo"]
         if page_info["hasNextPage"]:
             query_vars["cursor"] = page_info["endCursor"]
             page = page + 1

--- a/bin/github-backup
+++ b/bin/github-backup
@@ -527,6 +527,12 @@ def _request_http_error(exc, auth, errors):
 
         time.sleep(delta)
         should_continue = True
+    
+    elif exc.code == 422:
+        print("Potentially endpoint spammed detected, sleeping for 60 seconds and retrying")
+        time.sleep(60)
+        should_continue = True
+
     return errors, should_continue
 
 

--- a/bin/github-backup
+++ b/bin/github-backup
@@ -552,7 +552,7 @@ def _construct_graphql_request(url, query, query_vars, auth, req_type, page_no=1
         elif 'basic_auth' in auth:
             request.add_header('Authorization', 'Basic '.encode('ascii') + auth['basic_auth'])  # noqa
 
-    log_info('Requesting {}/{} {} Page {}'.format(query_vars["owner"], query_vars["repo"], req_type, page_no))
+    log_info('Requesting {}/{} {} Page: {}, State: {}'.format(query_vars["owner"], query_vars["repo"], req_type, page_no, query_vars["state"]))
     return request
 
 
@@ -586,9 +586,9 @@ def _request_http_error(exc, auth, errors):
         time.sleep(delta)
         should_continue = True
     
-    elif exc.code == 422:
-        print("Potentially endpoint spammed detected, sleeping for 60 seconds and retrying")
-        time.sleep(60)
+    elif exc.code == 502 or exc.code == 504:
+        print("Potential intermitent error, retrying...")
+        time.sleep(delta)
         should_continue = True
 
     return errors, should_continue
@@ -806,8 +806,6 @@ def backup_issues(args, repo_cwd, repository, repos_template):
                     number
                     title
                     body
-                    bodyText
-                    bodyHTML
                     state
                     stateReason
                     closed
@@ -837,40 +835,20 @@ def backup_issues(args, repo_cwd, repository, repos_template):
                         state
                         dueOn
                         createdAt
+                        number
+                        url
                     }
-                    reactions(first: 10) {
-                        nodes {
-                            content
-                            user {
-                                login
-                            }
-                        }
+                    reactions(first: 100) {
                         totalCount
+                        nodes{
+                            content
+                        }
                     }
                     comments(first: 10) {
                         totalCount
-                        nodes {
-                            body
-                            
-                            author {
-                                login
-                            }
-                            createdAt
-                        }
                     }
                     timelineItems(first: 10) {
                         totalCount
-                    }
-                    participants(first: 10) {
-                        nodes {
-                            login
-                        }
-                    }
-                    repository {
-                        name
-                        owner {
-                            login
-                        }
                     }
                 }
             }

--- a/bin/github-backup
+++ b/bin/github-backup
@@ -482,6 +482,8 @@ def retrieve_data_graphql(args, graphql_url, query, req_type, query_vars=None, s
         if page_info["hasNextPage"]:
             query_vars["cursor"] = page_info["endCursor"]
             page = page + 1
+        else:
+            break
         
         if single_request:
             break

--- a/bin/github-backup
+++ b/bin/github-backup
@@ -795,9 +795,9 @@ def backup_issues(args, repo_cwd, repository, repos_template):
     _issue_template = '{0}/{1}/issues'.format(repos_template,
                                               repository['full_name'])
     _issue_query = """
-    query ($owner: String!, $repo: String!, $after: String, $state: [IssueState!], $sort: IssueOrderField!, $direction: OrderDirection!, $perPage: Int!) {
+    query ($owner: String!, $repo: String!, $cursor: String, $state: [IssueState!], $sort: IssueOrderField!, $direction: OrderDirection!, $perPage: Int!) {
         repository(owner: $owner, name: $repo) {
-            issues(first: $perPage, after: $after, states: $state, orderBy: {field: $sort, direction: $direction}) {
+            issues(first: $perPage, after: $cursor, states: $state, orderBy: {field: $sort, direction: $direction}) {
                 pageInfo {
                     endCursor
                     hasNextPage
@@ -880,7 +880,7 @@ def backup_issues(args, repo_cwd, repository, repos_template):
     _issue_query_vars = {
         'owner': repository['owner']['login'],
         'repo': repository['name'],
-        'after': None,
+        'cursor': None,
         'perPage': 100,
         "direction": "DESC",
         "sort": "UPDATED_AT"
@@ -943,9 +943,9 @@ def backup_pulls(args, repo_cwd, repository, repos_template):
                                              repository['full_name'])
     
     _pulls_query = """
-    query ($owner: String!, $repo: String!, $after: String, $state: [PullRequestState!], $sort: IssueOrderField!, $direction: OrderDirection!, $perPage: Int!) {
+    query ($owner: String!, $repo: String!, $cursor: String, $state: [PullRequestState!], $sort: IssueOrderField!, $direction: OrderDirection!, $perPage: Int!) {
         repository(owner: $owner, name: $repo) {
-            pullRequests(first: $perPage, after: $after, states: $state, orderBy: {field: $sort, direction: $direction}) {
+            pullRequests(first: $perPage, after: $cursor, states: $state, orderBy: {field: $sort, direction: $direction}) {
                 pageInfo {
                     endCursor
                     hasNextPage
@@ -974,7 +974,7 @@ def backup_pulls(args, repo_cwd, repository, repos_template):
     _pull_query_vars = {
         'owner': repository['owner']['login'],
         'repo': repository['name'],
-        'after': None,
+        'cursor': None,
         'perPage': 100,
         "direction": "DESC",
         "sort": "UPDATED_AT"

--- a/bin/github-backup
+++ b/bin/github-backup
@@ -411,7 +411,6 @@ def _update_githubapp_token(current_token):
     else:
         log_error('No token found in ~/.gh-token')
 
-
 def retrieve_data(args, template, query_args=None, single_request=False):
     auth = get_auth(args)
     
@@ -450,13 +449,53 @@ def retrieve_data(args, template, query_args=None, single_request=False):
     return data
 
 
+def retrieve_data_graphql(args, graphql_url, query, req_type, query_vars=None, single_request=False):
+    # args, query, query_vars, single_request
+    auth = get_auth(args)
+    
+    per_page = 100
+    data = []
+    query_vars['perPage'] = per_page
+    page = 1
+
+    while True:
+        request = _construct_graphql_request(graphql_url, query, query_vars, auth, req_type, page)
+       
+        r, errors = _get_response(request, auth)
+        status_code = int(r.getcode())
+
+        if status_code != 200:
+            err_template = 'API request returned HTTP {0}: {1}'
+            errors.append(err_template.format(status_code, r.reason))
+            log_error(errors)
+            
+        decoded_json = json.loads(r.read().decode('utf-8'))
+        response = decoded_json.get('data', {}).get('repository', {}).get(req_type, {}).get('nodes', [])
+        if len(errors) == 0:
+            if type(response) == list:
+                data.extend(response)
+                if len(response) < per_page:
+                    break
+            elif type(response) == dict and single_request:
+                data.append(response)
+        page_info = response["data"]["repository"][req_type]["pageInfo"]
+        if page_info["hasNextPage"]:
+            query_vars["cursor"] = page_info["endCursor"]
+            page = page + 1
+        
+        if single_request:
+            break
+
+    return data
+
+
 def get_query_args(query_args=None):
     if not query_args:
         query_args = {}
     return query_args
 
 
-def _get_response(request, auth, template):
+def _get_response(request, auth, template=None):
     retry_timeout = 3
     errors = []
     # We'll make requests in a loop so we can
@@ -495,6 +534,23 @@ def _construct_request(per_page, page, query_args, template, auth):
             request.add_header('Authorization', 'Basic '.encode('ascii') + auth['basic_auth'])  # noqa
 
     log_info('Requesting {}?{}'.format(template, querystring))
+    return request
+
+
+def _construct_graphql_request(url, query, query_vars, auth, req_type, page_no=1):
+    body = body = json.dumps({
+        "query": query,
+        "variables": query_vars
+    }).encode('utf-8')
+    request = Request(url, data=body, method="POST")
+    if auth:
+        if 'token' in auth:
+            auth['token']= _update_githubapp_token(auth['token'])
+            request.add_header('Authorization', 'Bearer ' + auth['token'])  # noqa
+        elif 'basic_auth' in auth:
+            request.add_header('Authorization', 'Basic '.encode('ascii') + auth['basic_auth'])  # noqa
+
+    log_info('Requesting {}/{} {} Page {}'.format(query_vars["owner"], query_vars["repo"], req_type, page_no))
     return request
 
 
@@ -736,20 +792,111 @@ def backup_issues(args, repo_cwd, repository, repos_template):
     issues_skipped_message = ''
     _issue_template = '{0}/{1}/issues'.format(repos_template,
                                               repository['full_name'])
+    _issue_query = """
+    query ($owner: String!, $repo: String!, $after: String, $state: [IssueState!], $sort: IssueOrderField!, $direction: OrderDirection!, $perPage: Int!) {
+        repository(owner: $owner, name: $repo) {
+            issues(first: $perPage, after: $after, states: $state, orderBy: {field: $sort, direction: $direction}) {
+                pageInfo {
+                    endCursor
+                    hasNextPage
+                }
+                nodes {
+                    number
+                    title
+                    body
+                    bodyText
+                    bodyHTML
+                    state
+                    stateReason
+                    closed
+                    closedAt
+                    url
+                    createdAt
+                    updatedAt
+                    authorAssociation
+                    author {
+                        login
+                    }
+                    assignees(first: 10) {
+                        nodes {
+                            login
+                        }
+                    }
+                    labels(first: 10) {
+                        nodes {
+                            name
+                            color
+                            description
+                        }
+                    }
+                    milestone {
+                        title
+                        description
+                        state
+                        dueOn
+                        createdAt
+                    }
+                    reactions(first: 10) {
+                        nodes {
+                            content
+                            user {
+                                login
+                            }
+                        }
+                        totalCount
+                    }
+                    comments(first: 10) {
+                        totalCount
+                        nodes {
+                            body
+                            
+                            author {
+                                login
+                            }
+                            createdAt
+                        }
+                    }
+                    timelineItems(first: 10) {
+                        totalCount
+                    }
+                    participants(first: 10) {
+                        nodes {
+                            login
+                        }
+                    }
+                    repository {
+                        name
+                        owner {
+                            login
+                        }
+                    }
+                }
+            }
+        }
+    }
+    """
+    _issue_query_vars = {
+        'owner': repository['owner']['login'],
+        'repo': repository['name'],
+        'after': None,
+        'perPage': 100,
+        "direction": "DESC",
+        "sort": "UPDATED_AT"
+
+    }
+    graphql_url = 'https://{0}/graphql'.format(get_github_api_host(args))
 
     should_include_pulls = args.include_pulls or args.include_everything
-    issue_states = ['open', 'closed']
+    issue_states = ['OPEN', 'CLOSED']
     for issue_state in issue_states:
-        query_args = {
-            'filter': 'all',
-            'state': issue_state
-        }
-        if args.since:
-            query_args['since'] = args.since
+        _issue_query_vars['state'] = issue_state
+        _issues = retrieve_data_graphql(args, 
+                                graphql_url,
+                                _issue_query,
+                                query_vars=_issue_query_vars,
+                                 req_type='issues',
+                                 single_request=False)
 
-        _issues = retrieve_data(args,
-                                _issue_template,
-                                query_args=query_args)
         for issue in _issues:
             # skip pull requests which are also returned as issues
             # if retrieving pull requests is requested as well
@@ -792,30 +939,71 @@ def backup_pulls(args, repo_cwd, repository, repos_template):
     pulls = {}
     _pulls_template = '{0}/{1}/pulls'.format(repos_template,
                                              repository['full_name'])
-    query_args = {
-        'filter': 'all',
-        'state': 'all',
-        'sort': 'updated',
-        'direction': 'desc',
+    
+    _pulls_query = """
+    query ($owner: String!, $repo: String!, $after: String, $state: [PullRequestState!], $sort: IssueOrderField!, $direction: OrderDirection!, $perPage: Int!) {
+        repository(owner: $owner, name: $repo) {
+            pullRequests(first: $perPage, after: $after, states: $state, orderBy: {field: $sort, direction: $direction}) {
+                pageInfo {
+                    endCursor
+                    hasNextPage
+                }
+                nodes {
+                    author {
+                        login
+                    }
+                    baseRefName
+                    createdAt
+                    headRefName
+                    isDraft
+                    mergedAt
+                    mergeable
+                    number
+                    state
+                    title
+                    updatedAt
+                    url
+                }
+            }
+        }
+    }
+    """
+
+    _pull_query_vars = {
+        'owner': repository['owner']['login'],
+        'repo': repository['name'],
+        'after': None,
+        'perPage': 100,
+        "direction": "DESC",
+        "sort": "UPDATED_AT"
     }
 
+    graphql_url = 'https://{0}/graphql'.format(get_github_api_host(args))
+
     if not args.include_pull_details:
-        pull_states = ['open', 'closed']
+        pull_states = ['OPEN', 'CLOSED']
         for pull_state in pull_states:
-            query_args['state'] = pull_state
+            _pull_query_vars['state'] = pull_state
             # It'd be nice to be able to apply the args.since filter here...
-            _pulls = retrieve_data(args,
-                                   _pulls_template,
-                                   query_args=query_args)
+            _pulls = retrieve_data_graphql(args, 
+                                graphql_url,
+                                _pulls_query,
+                                query_vars=_pull_query_vars,
+                                 req_type='pullRequests',
+                                 single_request=False)
             for pull in _pulls:
-                if not args.since or pull['updated_at'] >= args.since:
+                if not args.since or pull['updatedAt'] >= args.since:
                     pulls[pull['number']] = pull
     else:
-        _pulls = retrieve_data(args,
-                               _pulls_template,
-                               query_args=query_args)
+        _pull_query_vars['state'] = ['OPEN', 'CLOSED']
+        _pulls = retrieve_data_graphql(args,
+                                graphql_url,
+                                _pulls_query,
+                                query_vars=_pull_query_vars,
+                                 req_type='pullRequests',
+                                 single_request=False)
         for pull in _pulls:
-            if not args.since or pull['updated_at'] >= args.since:
+            if not args.since or pull['updatedAt'] >= args.since:
                 pulls[pull['number']] = retrieve_data(
                     args,
                     _pulls_template + '/{}'.format(pull['number']),

--- a/bin/github-backup
+++ b/bin/github-backup
@@ -8,7 +8,7 @@ import calendar
 import codecs
 import errno
 import getpass
-import json
+from json import dump as json_dump, dumps as json_dumps, loads as json_loads
 import logging
 import os
 import re
@@ -411,6 +411,7 @@ def _update_githubapp_token(current_token):
     else:
         log_error('No token found in ~/.gh-token')
 
+
 def retrieve_data(args, template, query_args=None, single_request=False):
     auth = get_auth(args)
     
@@ -431,7 +432,7 @@ def retrieve_data(args, template, query_args=None, single_request=False):
             errors.append(err_template.format(status_code, r.reason))
             log_error(errors)
             
-        response = json.loads(r.read().decode('utf-8'))
+        response = json_loads(r.read().decode('utf-8'))
         if len(errors) == 0:
             if type(response) == list:
                 data.extend(response)
@@ -469,7 +470,7 @@ def retrieve_data_graphql(args, graphql_url, query, req_type, query_vars=None, s
             errors.append(err_template.format(status_code, r.reason))
             log_error(errors)
             
-        decoded_json = json.loads(r.read().decode('utf-8'))
+        decoded_json = json_loads(r.read().decode('utf-8'))
         response = decoded_json.get('data', {}).get('repository', {}).get(req_type, {}).get('nodes', [])
         if len(errors) == 0:
             if type(response) == list:
@@ -540,7 +541,7 @@ def _construct_request(per_page, page, query_args, template, auth):
 
 
 def _construct_graphql_request(url, query, query_vars, auth, req_type, page_no=1):
-    body = body = json.dumps({
+    body = body = json_dumps({
         "query": query,
         "variables": query_vars
     }).encode('utf-8')
@@ -552,7 +553,7 @@ def _construct_graphql_request(url, query, query_vars, auth, req_type, page_no=1
         elif 'basic_auth' in auth:
             request.add_header('Authorization', 'Basic '.encode('ascii') + auth['basic_auth'])  # noqa
 
-    log_info('Requesting {}/{} {} Page: {}, State: {}'.format(query_vars["owner"], query_vars["repo"], req_type, page_no, query_vars["state"]))
+    log_info(f"Requesting {query_vars['owner']}/{query_vars['owner']} {req_type} Page: {page_no}, State: {query_vars['owner']}")
     return request
 
 
@@ -587,7 +588,7 @@ def _request_http_error(exc, auth, errors):
         should_continue = True
     
     elif exc.code == 502 or exc.code == 504:
-        print("Potential intermitent error, retrying...")
+        print("Potential intermittent error, retrying...")
         time.sleep(delta)
         should_continue = True
 
@@ -748,7 +749,7 @@ def backup_repositories(args, output_directory, repositories):
                 # dump gist information to a file as well
                 output_file = '{0}/gist.json'.format(repo_cwd)
                 with codecs.open(output_file, 'w', encoding='utf-8') as f:
-                    json_dump(repository, f)
+                    json_dump_formatted(repository, f)
 
                 continue  # don't try to back anything else for a gist; it doesn't exist
 
@@ -904,7 +905,7 @@ def backup_issues(args, repo_cwd, repository, repos_template):
 
         issue_file = '{0}/{1}.json'.format(issue_cwd, number)
         with codecs.open(issue_file, 'w', encoding='utf-8') as f:
-            json_dump(issue, f)
+            json_dump_formatted(issue, f)
 
 
 def backup_pulls(args, repo_cwd, repository, repos_template):
@@ -1004,7 +1005,7 @@ def backup_pulls(args, repo_cwd, repository, repos_template):
 
         pull_file = '{0}/{1}.json'.format(pulls_cwd, number)
         with codecs.open(pull_file, 'w', encoding='utf-8') as f:
-            json_dump(pull, f)
+            json_dump_formatted(pull, f)
 
 
 def backup_milestones(args, repo_cwd, repository, repos_template):
@@ -1033,7 +1034,7 @@ def backup_milestones(args, repo_cwd, repository, repos_template):
     for number, milestone in list(milestones.items()):
         milestone_file = '{0}/{1}.json'.format(milestone_cwd, number)
         with codecs.open(milestone_file, 'w', encoding='utf-8') as f:
-            json_dump(milestone, f)
+            json_dump_formatted(milestone, f)
 
 
 def backup_labels(args, repo_cwd, repository, repos_template):
@@ -1186,11 +1187,11 @@ def _backup_data(args, name, template, output_file, output_directory):
 
         log_info('Writing {0} {1} to disk'.format(len(data), name))
         with codecs.open(output_file, 'w', encoding='utf-8') as f:
-            json_dump(data, f)
+            json_dump_formatted(data, f)
 
 
-def json_dump(data, output_file):
-    json.dump(data,
+def json_dump_formatted(data, output_file):
+    json_dump(data,
               output_file,
               ensure_ascii=False,
               sort_keys=True,


### PR DESCRIPTION
apply-github-backup has been failing recently because rest api does not support pagination over 100 pages. So I made it so that it uses graphql instead of rest api to be allow it to successfully backup all the issues and prs in a repo. 

Graphql page: https://docs.github.com/en/graphql/reference/objects#repository
Semaphore job with this change: 
- confluentinc: https://semaphore.ci.confluent.io/jobs/d8c659ba-7c37-489d-9523-0ab503f3f2c0
- confluent-partners: https://semaphore.ci.confluent.io/jobs/fc552d1d-b44a-4f5a-ac5c-aad6b3b197a8
https://confluentinc.atlassian.net/browse/DP-16134

Tested in the semaphore job above